### PR TITLE
Add media types and use remote file ext as fallback if unknown type

### DIFF
--- a/src/downloads.rs
+++ b/src/downloads.rs
@@ -79,11 +79,8 @@ fn download_file(mut ep_data: EpData, dest: PathBuf, mut max_retries: usize) -> 
     let response = request.unwrap();
 
     // figure out the file type
-    let ext = match get_file_ext(response.header("content-type"), &ep_data.url)
-    {
-        Some(ext) => ext,
-        None => "mp3", // assume .mp3 unless we figure out otherwise
-    };
+    // assume .mp3 unless we figure out otherwise
+    let ext = get_file_ext(response.header("content-type"), &ep_data.url).unwrap_or("mp3");
 
     let mut file_name = sanitize_with_options(
         &ep_data.title,
@@ -118,46 +115,42 @@ fn download_file(mut ep_data: EpData, dest: PathBuf, mut max_retries: usize) -> 
 /// Returns what the extension of a downloaded file should be, based first on
 /// its mime type, and then on its URL if the mime type is missing or unknown
 /// Reference: https://www.iana.org/assignments/media-types/media-types.xhtml
-fn get_file_ext<'a>(mime_type: Option<&str>, url: &'a str) -> Option<&'a str>
-{
-    match mime_type
-    {
+fn get_file_ext<'a>(mime_type: Option<&str>, url: &'a str) -> Option<&'a str> {
+    match mime_type {
         // Audio
-        Some("audio/3gpp")                        => Some("3gp"),
-        Some("audio/aac")                         => Some("aac"),
-        Some("audio/flac")                        => Some("flac"),
-        Some("audio/x-m4a")                       => Some("m4a"),
-        Some("audio/matroska")                    => Some("mka"),
+        Some("audio/3gpp") => Some("3gp"),
+        Some("audio/aac") => Some("aac"),
+        Some("audio/flac") => Some("flac"),
+        Some("audio/x-m4a") => Some("m4a"),
+        Some("audio/matroska") => Some("mka"),
         Some("audio/midi") | Some("audio/x-midi") => Some("mid"),
-        Some("audio/midi-clip")                   => Some("midi2"),
-        Some("audio/mp4")                         => Some("mp4"),
-        Some("audio/mpeg")                        => Some("mp3"),
-        Some("audio/ogg") | Some("audio/vorbis")  => Some("oga"),
-        Some("audio/opus")                        => Some("opus"),
-        Some("audio/wav")                         => Some("wav"),
-        Some("audio/webm")                        => Some("weba"),
+        Some("audio/midi-clip") => Some("midi2"),
+        Some("audio/mp4") => Some("mp4"),
+        Some("audio/mpeg") => Some("mp3"),
+        Some("audio/ogg") | Some("audio/vorbis") => Some("oga"),
+        Some("audio/opus") => Some("opus"),
+        Some("audio/wav") => Some("wav"),
+        Some("audio/webm") => Some("weba"),
         // Video
-        Some("video/3gpp")        => Some("3gp"),
-        Some("video/3gpp2")       => Some("3g2"),
-        Some("video/matroska")    => Some("mkv"),
+        Some("video/3gpp") => Some("3gp"),
+        Some("video/3gpp2") => Some("3g2"),
+        Some("video/matroska") => Some("mkv"),
         Some("video/matroska-3d") => Some("mk3d"),
-        Some("video/quicktime")   => Some("mov"),
-        Some("video/mp4")         => Some("mp4"),
-        Some("video/x-m4v")       => Some("m4v"),
+        Some("video/quicktime") => Some("mov"),
+        Some("video/mp4") => Some("mp4"),
+        Some("video/x-m4v") => Some("m4v"),
         // Otherwise, use the extension in the URL as a fallback
         _ => {
             // Look for what's after the last slash (/)
-            match url.rsplit('/').next()
-            {
+            match url.rsplit('/').next() {
                 Some(file_name) => {
                     // Look for what's after the last dot (.)
                     // Return Some(ext) if next returns Some(ext),
                     // return None if next returns None
                     file_name.rsplit('.').next()
-                },
-                None => None
+                }
+                None => None,
             }
         }
     }
 }
-


### PR DESCRIPTION
Hello!

This follows our discussion in https://github.com/gilcu3/hullcaster/issues/5. In this pull request, the extension of the file to be downloaded is decided in two steps:
1- the media type/MIME type is checked (more types were added in the list);
2- if the type is unknown, the extension in the URL is used.

The code to do that is longer than before, so I moved it to a separate function in order to keep the download function easier to read.